### PR TITLE
Fix val iterator reset

### DIFF
--- a/train.py
+++ b/train.py
@@ -100,8 +100,8 @@ if __name__=='__main__':
                     batch = next(val_dataloader_iter)
                     X_val, y_val = batch['X'], batch['Y']
                 except StopIteration:
-                    val_loader_iter = iter(val_dataloader)
-                    batch = next(val_loader_iter)
+                    val_dataloader_iter = iter(val_dataloader)
+                    batch = next(val_dataloader_iter)
                     X_val, y_val = batch['X'], batch['Y']
                 X_val = X_val.to(0)
                 y_val = y_val.to(0)


### PR DESCRIPTION
## Summary
- fix variable name when resetting validation iterator in `train.py`

## Testing
- `python -m py_compile datasets.py models.py train.py test.py sgd_single_depth.py get_lr.py scripts.py`
- `pyflakes *.py`
- `python train.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6842f07df42c833391a1c9bf90a2d6f2